### PR TITLE
initialize std::binary_semaphore

### DIFF
--- a/Chapter13/sync_wait.h
+++ b/Chapter13/sync_wait.h
@@ -56,7 +56,7 @@ class SyncWaitTask { // A helper class only used by sync_wait()
     std::exception_ptr error_;
 
 #if defined(__cpp_lib_semaphore)
-    std::binary_semaphore semaphore_;
+    std::binary_semaphore semaphore_{1};
 #else
     bool ready_{false};
     std::mutex mtx_;


### PR DESCRIPTION
As std::binary_semaphore doesn't have a default constructor, it needs to be initialized by the desired number between 0 and 1.